### PR TITLE
feat: CI/CD for frontends

### DIFF
--- a/.github/workflows/deploy-frontend-firebase.yml
+++ b/.github/workflows/deploy-frontend-firebase.yml
@@ -1,0 +1,77 @@
+name: Deploy Frontend to Firebase Hosting
+
+# Only trigger workflow when there is a push to the main branch
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy: # "deploy" is the name of the job
+    name: Running deploy job for ${{ matrix.app }} appplication
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        app: ["dashboard", "checkout"] # Run "deploy" job twice. We assign "dashboard" and "checkout" to the variable matrix.app for the separate job runs
+    steps:
+      - name: 1. Checkout Repository
+        uses: actions/checkout@v4
+
+        # This step checks if there are any changed files for our respective apps (e.g. apps/dashboard) along with any changes in packages/
+        # If there are, it would set steps.changed-files.outputs.any_changed to true
+        # Essentially, if no changes are found for the app, the job ends after this step
+
+      - name: 2. Get Changed Files
+        id: changed-files
+        uses: tj-actions/changed-files@v41
+        with:
+          files: |
+            apps/${{ matrix.app }}/**
+            packages/**
+
+      - name: 3. Setup PNPM
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: pnpm/action-setup@v3
+        with:
+          version: 10.11.0
+
+      - name: 4. Setup Node.js
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.14.0"
+          cache: "pnpm"
+
+      - name: 5. Install Dependencies
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: pnpm install
+
+      - name: 6. Build Application
+        if: steps.changed-files.outputs.any_changed == 'true'
+        # Gets the secrets stored in github actions and runs the build command
+        env:
+          REACT_APP_API_URL: ${{ secrets.REACT_APP_API_URL }}
+          REACT_APP_ENV: ${{ secrets.REACT_APP_ENV }}
+        # Calls the app's respective build command
+        run: pnpm build:ci:${{ matrix.app }}
+
+      - name: 7. Deploy to Firebase
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
+          channelId: live
+          projectId: recurcrypt-8a21d
+          target: ${{ matrix.app }} # Refers to the target in the firebase.json. This is how we know where the built assets are
+
+      - name: 8. Post Job Summary
+        run: |
+          if [[ "${{ steps.changed-files.outputs.any_changed }}" == "true" ]]; then
+            echo "### ✅ Deployment Successful for ${{ matrix.app }}" >> $GITHUB_STEP_SUMMARY
+            echo "A new version of the **${{ matrix.app }}** application has been deployed." >> $GITHUB_STEP_SUMMARY
+            echo "You can view the deployment at https://recurcrypt-${{ matrix.app }}.denliehoo.com" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### ⚪ No Changes Detected for ${{ matrix.app }}" >> $GITHUB_STEP_SUMMARY
+            echo "The deployment for the **${{ matrix.app }}** application was skipped as there were no relevant file changes." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -45,6 +45,7 @@ Server deployment is done using Render
 - pnpm build:dashboard
 - pnpm build:checkout
 - firebase deploy --only hosting:dashboard,hosting:checkout
+- Note: we can doing host:dashboard because we specified where our built assets are in our firebase.json config
 
 - To redeploy:
 - repeat the above

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ RecurCrypt is a full-stack application that enables businesses to accept recurri
 
 - **DevOps & Tooling:**
   - **AWS Lambda:** Used for running serverless functions, such as our cron jobs.
-  <!-- - **GitHub Actions:** For our Continuous Integration and Continuous Deployment (CI/CD) pipelines. -->
+  - **GitHub Actions:** For our Continuous Integration and Continuous Deployment (CI/CD) pipelines.
   - **Husky:** To manage and run Git hooks, ensuring code quality before commits.
   - **Biome:** A high-performance toolchain for linting, formatting, and more.
   - **pnpm:** A fast, disk space-efficient package manager.

--- a/TODOANDPROGRESS.md
+++ b/TODOANDPROGRESS.md
@@ -1,6 +1,7 @@
 # Todo:
 
-- CI/CD for FE
+- Tailwind for styling
+- Tanstack query for fetching api
 - GraphQL layer
 - CI/CD for server and maybe docker
 - Upgrade to React 19
@@ -147,3 +148,4 @@
 - Update subdomain
 - Do code splitting by routes
 - Build and deploy (test)
+- CI/CD for FE

--- a/apps/checkout/package.json
+++ b/apps/checkout/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "start": "cross-env PORT=3032 env-cmd -f .env.dev rspack serve --config rspack.config.js",
     "build": "cross-env env-cmd -f .env.prod rspack build --config rspack.config.prod.js",
+    "build:ci": "cross-env rspack build --config rspack.config.prod.js",
     "test": "echo \"No test configured yet\" && exit 0"
   },
   "eslintConfig": {

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "start": "cross-env PORT=3031 env-cmd -f .env.dev rspack serve --config rspack.config.js",
     "build": "cross-env env-cmd -f .env.prod rspack build --config rspack.config.prod.js",
+    "build:ci": "cross-env rspack build --config rspack.config.prod.js",
     "test": "echo \"No test configured yet\" && exit 0"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "dev:server": "pnpm --filter server dev",
     "build:dashboard": "pnpm --filter dashboard build",
     "build:checkout": "pnpm --filter checkout build",
+    "build:ci:dashboard": "pnpm --filter dashboard build:ci",
+    "build:ci:checkout": "pnpm --filter checkout build:ci",
     "prod:server": "pnpm --filter server prod",
     "prod:build-server": "pnpm --filter server build",
     "prod:server-dist": "pnpm --filter server prod-dist",


### PR DESCRIPTION
CI/CD pipeline to frontend apps
Upon pushing a commit to the main branch, a pipeline will be ran to build and deploy the frontend applications depending on what changes were made in the commit. 
As long as there any changes in the root `packages/` folder, the pipeline will be ran for both `dashboard` and `checkout`.
However, if there are only changes in the `apps/dashboard` or `apps/checkout` then the pipeline will only be ran for the dashboard, or, checkout app respectively.